### PR TITLE
Fix merge column and use init.dt event

### DIFF
--- a/lib/core/LyxeaDatatable.ts
+++ b/lib/core/LyxeaDatatable.ts
@@ -20,7 +20,7 @@ import Action, { ActionArgs } from '@plugins/action/Action';
 import DtButtons from './DtButtons';
 import Filters from './Filters';
 import LxRenderer from '@dto/Renderer';
-import {default  as jquery} from 'jquery';
+import { default as jquery } from 'jquery';
 
 //@ts-ignore
 window.JSZip = jszip;
@@ -254,32 +254,30 @@ class LyxeaDatatable<T>
 
     this.#dtButtons.parse(this.config.buttons);
 
-    jquery(`${this._ref}`)
-    .on('init.dt', (e, settings) => {
-        if ( e.namespace !== 'dt' ) {
-          return;
-        }
-        const dtInstance = settings.oInstance.api();
-        /**
-         * Adding filter inputs
-         */
-        if (lxConfig && lxConfig.filters) {
-          // @ts-ignore
-          this.#headerElement = new Filters(this.config, dtInstance).init(
-            this.#headerElement
-          );
-        }
+    jquery(`${this._ref}`).on('init.dt', (e, settings) => {
+      if (e.namespace !== 'dt') {
+        return;
+      }
+      const dtInstance = settings.oInstance.api();
+      /**
+       * Adding filter inputs
+       */
+      if (lxConfig && lxConfig.filters) {
+        // @ts-ignore
+        this.#headerElement = new Filters(this.config, dtInstance).init(
+          this.#headerElement
+        );
+      }
 
-        /**
-         * Fit scrollY to screen
-         */
-        if (lxConfig && lxConfig.scrollYFitToScreen){
-          this.scrollYFitToScreen();
-          // Force redraw (FitToScreen has an effect on the draw event)
-          dtInstance.draw();
-        }
-
-    })
+      /**
+       * Fit scrollY to screen
+       */
+      if (lxConfig && lxConfig.scrollYFitToScreen) {
+        this.scrollYFitToScreen();
+        // Force redraw (FitToScreen has an effect on the draw event)
+        dtInstance.draw();
+      }
+    });
     /**
      * Initializing datatable
      * Init event, get the datable instance on event.detail
@@ -300,9 +298,8 @@ class LyxeaDatatable<T>
 
   scrollYFitToScreen() {
     const self = this;
-    jquery(`${this._ref}`)
-    .on('draw.dt', (e, _) => {
-      if ( e.namespace !== 'dt' ) {
+    jquery(`${this._ref}`).on('draw.dt', (e, _) => {
+      if (e.namespace !== 'dt') {
         return;
       }
       const tabPosition = document.querySelector(

--- a/lib/dom/HeadersLxDom.ts
+++ b/lib/dom/HeadersLxDom.ts
@@ -55,10 +55,11 @@ class HeaderLxDom extends AbstractLxDom {
     );
 
     if (!Object.keys(groupedHeaders).length) return this.headerRef;
-    // if no groupheader is present, build only columns
+    // if no groupheader is present, build only columns (e.g. : there are only HeaderGroup.NONE groups)
     if (
-      Object.keys(groupedHeaders).length === 1 &&
-      Object.keys(groupedHeaders).some((el) => el.startsWith(HeaderGroup.NONE))
+      /*Object.keys(groupedHeaders).length === 1 ||
+      Object.keys(groupedHeaders).some((el) => el.startsWith(HeaderGroup.NONE))*/
+      !Object.keys(groupedHeaders).some(el => !el.startsWith(HeaderGroup.NONE))
     ) {
       const headerCells = this.$mainRowHeader(groupedHeaders);
       const mainHeaderWrapper = this.$headerWrapper(

--- a/lib/dom/HeadersLxDom.ts
+++ b/lib/dom/HeadersLxDom.ts
@@ -59,7 +59,9 @@ class HeaderLxDom extends AbstractLxDom {
     if (
       /*Object.keys(groupedHeaders).length === 1 ||
       Object.keys(groupedHeaders).some((el) => el.startsWith(HeaderGroup.NONE))*/
-      !Object.keys(groupedHeaders).some(el => !el.startsWith(HeaderGroup.NONE))
+      !Object.keys(groupedHeaders).some(
+        (el) => !el.startsWith(HeaderGroup.NONE)
+      )
     ) {
       const headerCells = this.$mainRowHeader(groupedHeaders);
       const mainHeaderWrapper = this.$headerWrapper(


### PR DESCRIPTION
If you have only standard column (mulitple headers config without any headerGroup), the merge doesn't work well.

Set the Filters construction in the 'init.dt' event for prevent the async operation (like when langage is an url)
Set the  scrollYFitToScreen fonction also in 'init.dt' event for better calculation
Add the offsetHeight calculate for .top and .bottom (if you use dom configuration)
