### PR TITLE
Update export, set orthogonal to 'export' …

### DIFF
--- a/dist/core/DtButtons.d.ts
+++ b/dist/core/DtButtons.d.ts
@@ -2,8 +2,17 @@ import { ButtonConfig, ConfigButtons } from 'datatables.net-dt';
 
 declare class DtButtons {
     getDefaults(): (string | {
+        extend: string;
+        exportOptions: {
+            orthogonal: string;
+        };
+        text?: undefined;
+        action?: undefined;
+    } | {
         text: string;
         action: (_: any, dt: any) => void;
+        extend?: undefined;
+        exportOptions?: undefined;
     })[];
     parse(config: true | ConfigButtons | (string | ButtonConfig)[]): true | ConfigButtons | (string | ButtonConfig)[];
 }

--- a/dist/lx_dt.js
+++ b/dist/lx_dt.js
@@ -53286,22 +53286,22 @@ var M1 = Cl.exports;
 const ks = /* @__PURE__ */ hl(M1), qa = {
   DATE_DAY: {
     render: function(a, v) {
-      return v === "display" || v === "filter" ? ks(a).format("DD/MM/YYYY") : a;
+      return v === "display" || v === "filter" || v === "export" ? ks(a).format("DD/MM/YYYY") : a;
     }
   },
   DATE_WITH_SECOND: {
     render: function(a, v) {
-      return v === "display" || v === "filter" ? ks(a).format("DD/MM/YYYY HH:mm:ss") : a;
+      return v === "display" || v === "filter" || v === "export" ? ks(a).format("DD/MM/YYYY HH:mm:ss") : a;
     }
   },
   LOCAL_NUMBER: {
     render: function(a, v) {
-      return v === "display" || v === "filter" ? a.toLocaleString() : a;
+      return v === "display" || v === "filter" || v === "export" ? a.toLocaleString() : a;
     }
   },
   BOOLEAN_OUI_NON: {
     render: function(a, v) {
-      return v === "display" || v === "filter" ? a === !0 ? "Oui" : "Non" : a;
+      return v === "display" || v === "filter" || v === "export" ? a === !0 ? "Oui" : "Non" : a;
     }
   },
   NUMBER_FIXED_2: {
@@ -53337,8 +53337,8 @@ const ks = /* @__PURE__ */ hl(M1), qa = {
     render: (a) => typeof a == "string" ? a.toLowerCase() : a
   },
   CUT_LONG_TEXT: {
-    createdCell: function(a, v) {
-      typeof v == "string" && v.length > 30 && (a.title = v, a.innerText = v.substring(0, 28) + "…");
+    render: function(a, v) {
+      return v === "display" && typeof a == "string" && a.length > 6 ? a.substring(0, 4) + "…" : a;
     }
   },
   CHECKBOX: {
@@ -53353,7 +53353,7 @@ const ks = /* @__PURE__ */ hl(M1), qa = {
         const v = a[1];
         return {
           render: function(g, w) {
-            return w === "display" || w === "filter" ? ks(g).format(v) : g;
+            return w === "display" || w === "filter" || w === "export" ? ks(g).format(v) : g;
           }
         };
       }
@@ -53773,13 +53773,28 @@ _i = new WeakMap(), mi = new WeakMap(), yi = new WeakMap(), to = new WeakMap(), 
 class Z1 {
   getDefaults() {
     return [
-      "copyHtml5",
-      "excelHtml5",
-      "csvHtml5",
+      {
+        extend: "copyHtml5",
+        exportOptions: {
+          orthogonal: "export"
+        }
+      },
+      {
+        extend: "excelHtml5",
+        exportOptions: {
+          orthogonal: "export"
+        }
+      },
+      {
+        extend: "csvHtml5",
+        exportOptions: {
+          orthogonal: "export"
+        }
+      },
       {
         text: "JSON",
         action: function(v, g) {
-          var w = g.buttons.exportData({ orthogonal: "export_json" });
+          var w = g.rows({ orthogonal: "export" }).data().toArray();
           Wn.fn.dataTable.fileSave(
             new Blob([JSON.stringify(w)]),
             "Exported_data.json"

--- a/lib/core/DtButtons.ts
+++ b/lib/core/DtButtons.ts
@@ -4,20 +4,23 @@ import $ from 'jquery';
 class DtButtons {
   getDefaults() {
     return [
-      {extend: 'copyHtml5',
+      {
+        extend: 'copyHtml5',
         exportOptions: {
-            orthogonal: 'export'
-        }
+          orthogonal: 'export',
+        },
       },
-      {extend: 'excelHtml5',
+      {
+        extend: 'excelHtml5',
         exportOptions: {
-            orthogonal: 'export'
-        }
+          orthogonal: 'export',
+        },
       },
-      {extend: 'csvHtml5',
+      {
+        extend: 'csvHtml5',
         exportOptions: {
-            orthogonal: 'export'
-        }
+          orthogonal: 'export',
+        },
       },
       {
         text: 'JSON',

--- a/lib/core/DtButtons.ts
+++ b/lib/core/DtButtons.ts
@@ -4,13 +4,25 @@ import $ from 'jquery';
 class DtButtons {
   getDefaults() {
     return [
-      'copyHtml5',
-      'excelHtml5',
-      'csvHtml5',
+      {extend: 'copyHtml5',
+        exportOptions: {
+            orthogonal: 'export'
+        }
+      },
+      {extend: 'excelHtml5',
+        exportOptions: {
+            orthogonal: 'export'
+        }
+      },
+      {extend: 'csvHtml5',
+        exportOptions: {
+            orthogonal: 'export'
+        }
+      },
       {
         text: 'JSON',
         action: function (_: any, dt: any) {
-          var data = dt.buttons.exportData({ orthogonal: 'export_json' });
+          var data = dt.rows({ orthogonal: 'export' }).data().toArray();
           // @ts-ignore
           $.fn.dataTable.fileSave(
             new Blob([JSON.stringify(data)]),

--- a/lib/dto/Renderer.ts
+++ b/lib/dto/Renderer.ts
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 const CustomRenderers: Record<string, any> = {
   DATE_DAY: {
     render: function (data: any, type: any) {
-      if (type === 'display' || type === 'filter') {
+      if (type === 'display' || type === 'filter' || type === 'export') {
         return dayjs(data).format('DD/MM/YYYY');
       }
       return data;
@@ -13,7 +13,7 @@ const CustomRenderers: Record<string, any> = {
   },
   DATE_WITH_SECOND: {
     render: function (data: any, type: any) {
-      if (type === 'display' || type === 'filter') {
+      if (type === 'display' || type === 'filter' || type === 'export') {
         return dayjs(data).format('DD/MM/YYYY HH:mm:ss');
       }
       return data;
@@ -21,7 +21,7 @@ const CustomRenderers: Record<string, any> = {
   },
   LOCAL_NUMBER: {
     render: function (data: any, type: any) {
-      if (type === 'display' || type === 'filter') {
+      if (type === 'display' || type === 'filter' || type === 'export') {
         return data.toLocaleString();
       }
       return data;
@@ -29,7 +29,7 @@ const CustomRenderers: Record<string, any> = {
   },
   BOOLEAN_OUI_NON: {
     render: function (data: any, type: any) {
-      if (type === 'display' || type === 'filter') {
+      if (type === 'display' || type === 'filter' || type === 'export') {
         return data === true ? 'Oui' : 'Non';
       }
       return data;
@@ -75,14 +75,16 @@ const CustomRenderers: Record<string, any> = {
       typeof data === 'string' ? data.toLowerCase() : data,
   },
   CUT_LONG_TEXT: {
-    createdCell: function (td: any, cellData: any) {
-      if (typeof cellData === 'string') {
-        if (cellData.length > 30) {
-          td.title = cellData;
-          td.innerText = cellData.substring(0, 28) + '…';
+    render: function (data: any, type: any) {
+      if (type === 'display') {
+        if (typeof data === 'string') {
+          if (data.length > 6) {
+            return data.substring(0, 4) + '…';
+          }
         }
       }
-    },
+      return data;
+    }
   },
   CHECKBOX: {
     checkboxes: {
@@ -96,8 +98,7 @@ const CustomRenderers: Record<string, any> = {
         const format = match[1];
         return {
           render: function (data: any, type: any) {
-            if (type === 'display' || type === 'filter') {
-              //return moment(data).format(format);
+            if (type === 'display' || type === 'filter' || type === 'export') {
               return dayjs(data).format(format);
             }
             return data;

--- a/lib/dto/Renderer.ts
+++ b/lib/dto/Renderer.ts
@@ -84,7 +84,7 @@ const CustomRenderers: Record<string, any> = {
         }
       }
       return data;
-    }
+    },
   },
   CHECKBOX: {
     checkboxes: {


### PR DESCRIPTION
All default export have the orthogonal value to 'export' to be able to dissociate them in the renders.
For example, the CUT_LONG_TEXT renderer;
Update json export to a standard array